### PR TITLE
Bad name argument for summary function in first chunk of "Constructing Graphs" section

### DIFF
--- a/vignettes/igraph.Rmd
+++ b/vignettes/igraph.Rmd
@@ -204,7 +204,7 @@ In addition to `make_empty_graph()`, `make_graph()`, and `make_graph_from_litera
 
 ```{r echo = TRUE}
 graph1 <- make_tree(127, 2, mode = "undirected")
-summary(g)
+summary(graph1)
 ```
 
 This generates a regular tree graph with 127 vertices, each vertex having two children. No matter how many times you call `make_tree()`, the generated graph will always be the same if you use the same parameters:


### PR DESCRIPTION
A graph object named `graph1` has been created.
But the summary function takes a graph object named `g` as argument instead of `graph1`